### PR TITLE
example poco mapping bug fix, and type matching suggestion

### DIFF
--- a/src/KuzuDot.Examples/Pet.cs
+++ b/src/KuzuDot.Examples/Pet.cs
@@ -1,0 +1,8 @@
+namespace KuzuDot.Examples
+{
+    internal sealed class Pet
+    {
+        public string? name { get; set; }
+        public long age { get; set; }
+    }
+}

--- a/src/KuzuDot.Examples/Program.cs
+++ b/src/KuzuDot.Examples/Program.cs
@@ -62,8 +62,11 @@ namespace KuzuDot.Examples
             long count = connection.ExecuteScalar<long>("MATCH (p:Person) RETURN COUNT(*)");
             ExampleLog.Info($"Person count (ExecuteScalar): {count}");
             // Ergonomic: POCO mapping
-            var people = connection.Query<Person>("MATCH (p:Person) RETURN p.name, p.age");
+            var people = connection.Query<Person>("MATCH (p:Person) RETURN p.name AS name, p.age AS age");
             foreach (var p in people) ExampleLog.Info($"Person: {p.name}, Age: {p.age}");
+            // Ergonomic2: POCO mapping
+            var pet = connection.Query<Pet>("MATCH (p:Person) RETURN p");
+            foreach (var p in pet) ExampleLog.Info($"Pet: {p.name}, Age: {p.age}");
             // Async query example
             var asyncTask = connection.QueryAsync("MATCH (p:Person) RETURN p.name, p.age");
             asyncTask.Wait();

--- a/src/KuzuDot/Connection.cs
+++ b/src/KuzuDot/Connection.cs
@@ -271,27 +271,62 @@ namespace KuzuDot
                 for (int c = 0; c < columnCount; c++)
                 {
                     using var value = row.GetValue((ulong)c);
-                    var colName = columnNames[c];
-                    if (propMap.TryGetValue(colName, out var prop))
+                    if (value.DataTypeId == KuzuDataTypeId.KuzuNode)
                     {
-                        try
+                        using KuzuNode aKuzuNode = (KuzuNode)KuzuNode.FromNative(value.NativePtr);
+                        //if(aKuzuNode.Label==typeof(T).Name) // use this to match Label to <T> typeName
+                        if (true)
                         {
-                            var converted = KuzuValue.ConvertKuzuValue(prop.PropertyType, value);
-                            prop.SetValue(instance, converted);
+                            foreach (var aProp in aKuzuNode.Properties)
+                            {
+                                if (propMap.TryGetValue(aProp.Key, out var propp))
+                                {
+                                    try
+                                    {
+                                        var converted = KuzuValue.ConvertKuzuValue(propp.PropertyType, aProp.Value);
+                                        propp.SetValue(instance, converted);
+                                    }
+                                    catch (System.InvalidCastException) { }
+                                    catch (System.FormatException) { }
+                                    continue;
+                                }
+                                if (fieldMap.TryGetValue(aProp.Key, out var fieldd))
+                                {
+                                    try
+                                    {
+                                        var converted = KuzuValue.ConvertKuzuValue(fieldd.FieldType, aProp.Value);
+                                        fieldd.SetValue(instance, converted);
+                                    }
+                                    catch (System.InvalidCastException) { }
+                                    catch (System.FormatException) { }
+                                }
+                            }
                         }
-                        catch (System.InvalidCastException) { }
-                        catch (System.FormatException) { }
-                        continue;
                     }
-                    if (fieldMap.TryGetValue(colName, out var field))
+                    else
                     {
-                        try
+                        var colName = columnNames[c];
+                        if (propMap.TryGetValue(colName, out var prop))
                         {
-                            var converted = KuzuValue.ConvertKuzuValue(field.FieldType, value);
-                            field.SetValue(instance, converted);
+                            try
+                            {
+                                var converted = KuzuValue.ConvertKuzuValue(prop.PropertyType, value);
+                                prop.SetValue(instance, converted);
+                            }
+                            catch (System.InvalidCastException) { }
+                            catch (System.FormatException) { }
+                            continue;
                         }
-                        catch (System.InvalidCastException) { }
-                        catch (System.FormatException) { }
+                        if (fieldMap.TryGetValue(colName, out var field))
+                        {
+                            try
+                            {
+                                var converted = KuzuValue.ConvertKuzuValue(field.FieldType, value);
+                                field.SetValue(instance, converted);
+                            }
+                            catch (System.InvalidCastException) { }
+                            catch (System.FormatException) { }
+                        }
                     }
                 }
                 list.Add(instance);


### PR DESCRIPTION
add pet to enable working with types named different from labels
fix POCO mapping bug "match (p:person) return p.name as name, p.age as age;"
add POCO mapping to match type not requiring the use of all field names "match (p:person) return p;"