### PR TITLE
Add test action; fix warnings; reorg KuzuInternalId

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,28 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: .NET
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal --filter "TestCategory!=Stress"

--- a/src/KuzuDot.Tests/ArrowTests/ArrowIntegrationExampleTest.cs
+++ b/src/KuzuDot.Tests/ArrowTests/ArrowIntegrationExampleTest.cs
@@ -90,7 +90,7 @@ namespace KuzuDot.Tests.ArrowTests
         private static long[] ReadInt64Values(KuzuDot.ArrowArray primitive)
         {
             long len = primitive.length;
-            if (len <= 0) return System.Array.Empty<long>();
+            if (len <= 0) return [];
             if (primitive.buffers == IntPtr.Zero)
                 throw new InvalidOperationException("Buffers pointer null");
 

--- a/src/KuzuDot.Tests/GlobalSuppressions.cs
+++ b/src/KuzuDot.Tests/GlobalSuppressions.cs
@@ -6,3 +6,4 @@
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("Maintainability", "CA1515:Consider making public types internal", Justification = "Test Project", Scope = "module")]
+[assembly: SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test Project", Scope = "module")]

--- a/src/KuzuDot.Tests/StressTests/FinalizerDisposalStressTests.cs
+++ b/src/KuzuDot.Tests/StressTests/FinalizerDisposalStressTests.cs
@@ -13,6 +13,7 @@ namespace KuzuDot.Tests.StressTests
     /// QueryResult disposal during finalization causes access violations, so it is excluded here.
     /// </summary>
     [TestClass]
+    [TestCategory("Stress")]
     public sealed class FinalizerDisposalStressTests
     {
         private const int Iterations = 500;
@@ -25,10 +26,10 @@ namespace KuzuDot.Tests.StressTests
             for (int i = 0; i < LargeIterations; i++)
             {
 #pragma warning disable CA2000 // Dispose objects before losing scope
-                var v1 = KuzuValueFactory.CreateInt64(i);
-                var v2 = KuzuValueFactory.CreateString($"str_{i}");
-                var v3 = KuzuValueFactory.CreateBool(i % 2 == 0);
-                var v4 = KuzuValueFactory.CreateNull();
+                _ = KuzuValueFactory.CreateInt64(i);
+                _ = KuzuValueFactory.CreateString($"str_{i}");
+                _ = KuzuValueFactory.CreateBool(i % 2 == 0);
+                _ = KuzuValueFactory.CreateNull();
 #pragma warning restore CA2000 // Dispose objects before losing scope
                 // Do not call Dispose
             }
@@ -68,8 +69,8 @@ namespace KuzuDot.Tests.StressTests
             GC.WaitForPendingFinalizers();
             using var result2 = conn.Query("MATCH (x:T) RETURN x.id;");
             using var summary2 = result2.GetQuerySummary();
-            Assert.IsTrue(summary2.CompilingTimeMs >= 0);
-            Assert.IsTrue(summary2.ExecutionTimeMs >= 0);
+            Assert.IsGreaterThanOrEqualTo(0, summary2.CompilingTimeMs);
+            Assert.IsGreaterThanOrEqualTo(0, summary2.ExecutionTimeMs);
         }
     }
 }

--- a/src/KuzuDot/KuzuDot.csproj
+++ b/src/KuzuDot/KuzuDot.csproj
@@ -34,6 +34,11 @@
       <Pack>true</Pack>
       <PackagePath>runtimes/win-x64/native</PackagePath>
     </Content>
+    <!-- Also copy to main output directory for easier loading -->
+    <Content Include="..\..\native\win-x64\kuzu_shared.dll">
+      <Link>kuzu_shared.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/KuzuDot/Value/KuzuInternalId.cs
+++ b/src/KuzuDot/Value/KuzuInternalId.cs
@@ -1,0 +1,38 @@
+﻿using KuzuDot.Enums;
+using KuzuDot.Native;
+using KuzuDot.Utils;
+using System;
+
+namespace KuzuDot.Value
+{
+    public sealed class KuzuInternalId : KuzuTypedValue<InternalId>
+    {
+        internal KuzuInternalId(NativeKuzuValue n) : base(n)
+        {
+        }
+
+        internal KuzuInternalId(IntPtr ptr) : base(ptr)
+        {
+        }
+
+        protected override bool TryGetNativeValue(out InternalId v)
+        {
+            var st = NativeMethods.kuzu_value_get_internal_id(ref Handle.NativeStruct, out var temp);
+            if (st == KuzuState.Success)
+            {
+                v = new InternalId(temp.TableId, temp.Offset);
+                return true;
+            }
+            v = default;
+            return false;
+        }
+
+        public static InternalId FromKuzuInternalId(KuzuInternalId v)
+        {
+            KuzuGuard.NotNull(v, nameof(v));
+            return v.Value;
+        }
+
+        public static implicit operator InternalId(KuzuInternalId value) => FromKuzuInternalId(value);
+    }
+}

--- a/src/KuzuDot/Value/KuzuTypedValues.cs
+++ b/src/KuzuDot/Value/KuzuTypedValues.cs
@@ -341,37 +341,6 @@ namespace KuzuDot.Value
         public static implicit operator string(KuzuString value) => FromKuzuString(value);
     }
 
-    public sealed class KuzuInternalId : KuzuTypedValue<InternalId>
-    {
-        internal KuzuInternalId(NativeKuzuValue n) : base(n)
-        {
-        }
-
-        internal KuzuInternalId(IntPtr ptr) : base(ptr)
-        {
-        }
-
-        protected override bool TryGetNativeValue(out InternalId v)
-        {
-            var st = NativeMethods.kuzu_value_get_internal_id(ref Handle.NativeStruct, out var temp);
-            if (st == KuzuState.Success)
-            {
-                v = new InternalId(temp.TableId, temp.Offset);
-                return true;
-            }
-            v = default;
-            return false;
-        }
-
-        public static InternalId FromKuzuInternalId(KuzuInternalId v)
-        {
-            KuzuGuard.NotNull(v, nameof(v));
-            return v.Value;
-        }
-
-        public static implicit operator InternalId(KuzuInternalId value) => FromKuzuInternalId(value);
-    }
-
     public sealed class KuzuInt128 : KuzuTypedValue<BigInteger>
     {
         internal KuzuInt128(NativeKuzuValue n) : base(n)


### PR DESCRIPTION
# Summary

- Added GitHub action to run tests
- Fixed (or suppressed) warnings in tests
- Moved KuzuInternalId to its own file
- Move a copy of `kuzu_shared.dll` to output so that other projects using KuzuDot can reference it easier.

# Details

### Test Infrastructure and Cancellation Improvements

* Enhanced cancellation support in stress tests by consistently passing `TestContext.CancellationToken` to `Task.Delay`, `Task.Run`, and query execution methods in `ConcurrencyStressTests.cs`, ensuring tests can be cancelled more reliably. [[1]](diffhunk://#diff-e26cc9f45875773ae6557aaa0e81fb59ec827c38b8a3319fac9c28d57d09b491L84-R88) [[2]](diffhunk://#diff-e26cc9f45875773ae6557aaa0e81fb59ec827c38b8a3319fac9c28d57d09b491L108-R111) [[3]](diffhunk://#diff-e26cc9f45875773ae6557aaa0e81fb59ec827c38b8a3319fac9c28d57d09b491L139-R137) [[4]](diffhunk://#diff-e26cc9f45875773ae6557aaa0e81fb59ec827c38b8a3319fac9c28d57d09b491L155-R153)
* Added a `TestContext` property to the stress test class to provide access to the test's cancellation token.
* Added a new GitHub Actions workflow `.github/workflows/dotnet.yml` to automate building and testing the .NET project on pushes and pull requests to the `main` branch.

### Code Organization and Maintainability

* Moved the `KuzuInternalId` class from `KuzuTypedValues.cs` into its own file `KuzuInternalId.cs` for better code organization. [[1]](diffhunk://#diff-45c59b4a86db578c63a175c1646f21fccffdf56ab164eff7f20c3a6fb6adec0aR1-R38) [[2]](diffhunk://#diff-d2a82e553d6eb3732c18a545f5600a4b3104a5945f7b765ea9d52fab7baad3b6L344-L374)
* Suppressed the CA1707 naming warning for underscores in identifiers in the test project, improving code clarity and reducing unnecessary warnings.

### Test Code Modernization and Assertion Improvements

* Updated test assertions in `FinalizerDisposalStressTests.cs` to use `Assert.IsGreaterThanOrEqualTo` for clarity and modernized test code by using discard assignments when creating objects intended for finalizer testing. [[1]](diffhunk://#diff-99d6fe6e9bd55ca5f5fd467d762aa50c2c922e974dacab0e317ab9fc4b451267L28-R32) [[2]](diffhunk://#diff-99d6fe6e9bd55ca5f5fd467d762aa50c2c922e974dacab0e317ab9fc4b451267L71-R73)
* Marked `FinalizerDisposalStressTests` with the `TestCategory("Stress")` attribute for better test categorization.
* Minor modernization in test code, such as using array literals and removing unnecessary pragma directives. [[1]](diffhunk://#diff-9ceb0755785dc643b12db98fa3adc56d0d251d0d78bbc8af76aaba984ce7ed58L93-R93) [[2]](diffhunk://#diff-e26cc9f45875773ae6557aaa0e81fb59ec827c38b8a3319fac9c28d57d09b491L125-L128)

### Native Dependency Output Management

* Updated `KuzuDot.csproj` to ensure that `kuzu_shared.dll` is copied to the main output directory, simplifying native library loading during development and testing.