### PR TITLE
Various helper methods on Connection to read/change DB schema

### DIFF
--- a/src/KuzuDot/DataType.cs
+++ b/src/KuzuDot/DataType.cs
@@ -1,10 +1,9 @@
 using KuzuDot.Enums;
 using KuzuDot.Native;
 using KuzuDot.Utils;
+using KuzuDot.Value;
 using System;
-using System.Diagnostics;
 
-#if INCLUDE_DATATYPE
 
 namespace KuzuDot
 {
@@ -87,6 +86,116 @@ namespace KuzuDot
             KuzuGuard.NotDisposed(_handle.IsInvalid, nameof(DataType));
         }
 
+        public static string GetNameFromType(KuzuDataTypeId dataTypeId)
+        {
+            return dataTypeId switch
+            {
+                KuzuDataTypeId.KuzuAny => "ANY",
+                KuzuDataTypeId.KuzuSerial => "SERIAL",
+                KuzuDataTypeId.KuzuInternalId => "INTERNAL_ID", // Not sure?
+                KuzuDataTypeId.KuzuUUID => "UUID",
+                KuzuDataTypeId.KuzuBool => "BOOL",
+                KuzuDataTypeId.KuzuInt64 => "INT64",
+                KuzuDataTypeId.KuzuInt32 => "INT32",
+                KuzuDataTypeId.KuzuInt16 => "INT16",
+                KuzuDataTypeId.KuzuInt8 => "INT8",
+                KuzuDataTypeId.KuzuUInt64 => "UINT64",
+                KuzuDataTypeId.KuzuUInt32 => "UINT32",
+                KuzuDataTypeId.KuzuUInt16 => "UINT16",
+                KuzuDataTypeId.KuzuUInt8 => "UINT8",
+                KuzuDataTypeId.KuzuFloat => "FLOAT",
+                KuzuDataTypeId.KuzuDouble => "DOUBLE",
+                KuzuDataTypeId.KuzuInt128 => "INT128",
+                KuzuDataTypeId.KuzuDate => "DATE",
+                KuzuDataTypeId.KuzuTimestamp => "TIMESTAMP",
+                KuzuDataTypeId.KuzuInterval => "INTERVAL",
+                KuzuDataTypeId.KuzuString => "STRING",
+                KuzuDataTypeId.KuzuBlob => "BLOB",
+                KuzuDataTypeId.KuzuNode => "NODE",
+                KuzuDataTypeId.KuzuList => "LIST",
+                KuzuDataTypeId.KuzuStruct => "STRUCT",
+                KuzuDataTypeId.KuzuMap => "MAP",
+                KuzuDataTypeId.KuzuArray => "ARRAY",
+                KuzuDataTypeId.KuzuRel => "REL",
+                KuzuDataTypeId.KuzuRecursiveRel => "RECURSIVE_REL", // Not sure
+                KuzuDataTypeId.KuzuUnion => "UNION",
+                KuzuDataTypeId.KuzuPointer => "POINTER",
+                KuzuDataTypeId.KuzuTimestampSec => "TIMESTAMP_SEC", // Not sure
+                KuzuDataTypeId.KuzuTimestampMs => "TIMESTAMP_MS",   // Not sure
+                KuzuDataTypeId.KuzuTimestampNs => "TIMESTAMP_NS",   // Not sure
+                KuzuDataTypeId.KuzuTimestampTz => "TIMESTAMP_TZ",   // Not sure
+                _ => "UNKNOWN"
+            };
+        }
+
+        public static KuzuDataTypeId GetDataTypeFromName(string name)
+        {
+            return name?.ToUpperInvariant() switch
+            {
+                "ANY" => KuzuDataTypeId.KuzuAny,
+                "SERIAL" => KuzuDataTypeId.KuzuSerial,
+                "INTERNAL_ID" => KuzuDataTypeId.KuzuInternalId,
+                "UUID" => KuzuDataTypeId.KuzuUUID,
+                "BOOL" => KuzuDataTypeId.KuzuBool,
+                "INT64" => KuzuDataTypeId.KuzuInt64,
+                "INT32" => KuzuDataTypeId.KuzuInt32,
+                "INT16" => KuzuDataTypeId.KuzuInt16,
+                "INT8" => KuzuDataTypeId.KuzuInt8,
+                "UINT64" => KuzuDataTypeId.KuzuUInt64,
+                "UINT32" => KuzuDataTypeId.KuzuUInt32,
+                "UINT16" => KuzuDataTypeId.KuzuUInt16,
+                "UINT8" => KuzuDataTypeId.KuzuUInt8,
+                "FLOAT" => KuzuDataTypeId.KuzuFloat,
+                "DOUBLE" => KuzuDataTypeId.KuzuDouble,
+                "INT128" => KuzuDataTypeId.KuzuInt128,
+                "DATE" => KuzuDataTypeId.KuzuDate,
+                "TIMESTAMP" => KuzuDataTypeId.KuzuTimestamp,
+                "INTERVAL" => KuzuDataTypeId.KuzuInterval,
+                "STRING" => KuzuDataTypeId.KuzuString,
+                "BLOB" => KuzuDataTypeId.KuzuBlob,
+                "NODE" => KuzuDataTypeId.KuzuNode,
+                "LIST" => KuzuDataTypeId.KuzuList,
+                "STRUCT" => KuzuDataTypeId.KuzuStruct,
+                "MAP" => KuzuDataTypeId.KuzuMap,
+                "ARRAY" => KuzuDataTypeId.KuzuArray,
+                "REL" => KuzuDataTypeId.KuzuRel,
+                "RECURSIVE_REL" => KuzuDataTypeId.KuzuRecursiveRel,
+                "UNION" => KuzuDataTypeId.KuzuUnion,
+                "POINTER" => KuzuDataTypeId.KuzuPointer,
+                "TIMESTAMP_SEC" => KuzuDataTypeId.KuzuTimestampSec,
+                "TIMESTAMP_MS" => KuzuDataTypeId.KuzuTimestampMs,
+                "TIMESTAMP_NS" => KuzuDataTypeId.KuzuTimestampNs,
+                "TIMESTAMP_TZ" => KuzuDataTypeId.KuzuTimestampTz,
+                _ => throw new ArgumentException($"Unknown data type name: {name}", nameof(name))
+            };
+        }
+
+        internal static KuzuDataTypeId GetIdFromType(Type type)
+        {
+            return type switch 
+            {
+                Type t when t == typeof(bool) => KuzuDataTypeId.KuzuBool,
+                Type t when t == typeof(sbyte) => KuzuDataTypeId.KuzuInt8,
+                Type t when t == typeof(short) => KuzuDataTypeId.KuzuInt16,
+                Type t when t == typeof(int) => KuzuDataTypeId.KuzuInt32,
+                Type t when t == typeof(long) => KuzuDataTypeId.KuzuInt64,
+                Type t when t == typeof(byte) => KuzuDataTypeId.KuzuUInt8,
+                Type t when t == typeof(ushort) => KuzuDataTypeId.KuzuUInt16,
+                Type t when t == typeof(uint) => KuzuDataTypeId.KuzuUInt32,
+                Type t when t == typeof(ulong) => KuzuDataTypeId.KuzuUInt64,
+                Type t when t == typeof(float) => KuzuDataTypeId.KuzuFloat,
+                Type t when t == typeof(double) => KuzuDataTypeId.KuzuDouble,
+                Type t when t == typeof(string) => KuzuDataTypeId.KuzuString,
+                Type t when t == typeof(byte[]) => KuzuDataTypeId.KuzuBlob,
+                Type t when t == typeof(UUID) => KuzuDataTypeId.KuzuUUID,
+#if NET8_0_OR_GREATER
+                Type t when t == typeof(DateOnly) => KuzuDataTypeId.KuzuDate,
+#endif
+                Type t when t == typeof(DateTime) => KuzuDataTypeId.KuzuTimestamp,
+                _ => throw new ArgumentException($"Unsupported CLR type for mapping to Kuzu data type: {type.FullName}", nameof(type))
+            };
+        }
+
         private sealed class DataTypeSafeHandle : KuzuSafeHandle
         {
             internal NativeKuzuLogicalType NativeStruct;
@@ -105,5 +214,3 @@ namespace KuzuDot
         }
     }
 }
-
-#endif

--- a/src/KuzuDot/SchemaConnection.cs
+++ b/src/KuzuDot/SchemaConnection.cs
@@ -1,0 +1,14 @@
+﻿namespace KuzuDot
+{
+    /// <summary>
+    /// Represents a mapping between source and target database tables, including their primary key columns.
+    /// </summary>
+    /// <remarks>This class represents the results of show_connection('table')</remarks>
+    public class SchemaConnection
+    {
+        public string SourceTable { get; set; } = default!;
+        public string TargetTable { get; set; } = default!;
+        public string SourcePrimaryKey { get; set; } = default!;
+        public string TargetPrimaryKey { get; set; } = default!;
+    }
+}

--- a/src/KuzuDot/SchemaProperty.cs
+++ b/src/KuzuDot/SchemaProperty.cs
@@ -1,0 +1,18 @@
+﻿namespace KuzuDot
+{
+    /// <summary>
+    /// Represents a property of an entity in the Kùzu database schema, including its identifier, name, type, default
+    /// expression, and primary key status.
+    /// </summary>
+    /// <remarks>Use this class to describe the metadata of a property within a node or relationship type in
+    /// the Kùzu database. Each instance encapsulates information about a single property, which can be used for schema
+    /// inspection or dynamic data handling.</remarks>
+    public class SchemaProperty
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = default!;
+        public string Type { get; set; } = default!;
+        public string DefaultExpression { get; set; } = default!;
+        public bool IsPrimaryKey { get; set; }
+    }
+}

--- a/src/KuzuDot/SchemaTable.cs
+++ b/src/KuzuDot/SchemaTable.cs
@@ -1,0 +1,13 @@
+﻿namespace KuzuDot
+{
+    /// <summary>
+    /// Represents metadata information for a database table schema
+    /// </summary>
+    public class SchemaTable
+    {
+        public ulong Id { get; set; }
+        public string Name { get; set; } = default!;
+        public string Type { get; set; } = default!;
+        public string Comment { get; set; } = default!;
+    }
+}


### PR DESCRIPTION
* Introduced new classes: `SchemaTable`, `SchemaProperty`, and `SchemaConnection`, for metadata about database schema.

* Added static methods to `DataType.cs` for converting between `KuzuDataTypeId` and string representations, and for mapping CLR types to Kuzu data types.

* Updated async test code to use `TestContext.CancellationToken` for better cancellation handling.

* Added tests for new code