### PR TITLE
Add handling backticks in names in Connection helper methods; Fix GetTableInfo

### DIFF
--- a/src/KuzuDot/SchemaTable.cs
+++ b/src/KuzuDot/SchemaTable.cs
@@ -9,5 +9,6 @@
         public string Name { get; set; } = default!;
         public string Type { get; set; } = default!;
         public string Comment { get; set; } = default!;
+        public string DatabaseName { get; set; } = default!;
     }
 }

--- a/src/KuzuDot/Utils/KuzuGuard.cs
+++ b/src/KuzuDot/Utils/KuzuGuard.cs
@@ -53,11 +53,7 @@ namespace KuzuDot.Utils
         internal static void StringContainsNull(string? value, string v)
         {
             var hasNull =
-#if NET8_0_OR_GREATER
                 value!.Contains('\0', StringComparison.Ordinal);
-#else
-                value!.IndexOf('\0') >= 0;
-#endif
             if (hasNull)
                 throw new ArgumentException($"String parameter '{v}' contains null character(s)", v);
         }

--- a/src/KuzuDot/Utils/KuzuStringExtensions.cs
+++ b/src/KuzuDot/Utils/KuzuStringExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace KuzuDot.Utils
+{
+    internal static class KuzuStringExtensions
+    {
+
+#if NETSTANDARD2_0
+        /// <summary>
+        /// Helper method to avoid .NET Framework issues with String.Contains and StringComparison
+        /// </summary>
+        /// <param name="source">Source String</param>
+        /// <param name="toCheck">String to check for</param>
+        /// <param name="comp">Comparision Type</param>
+        /// <returns>true if the source string contains the check string</returns>
+        internal static bool Contains(this string source, string toCheck, StringComparison comp)
+        {
+            return source?.IndexOf(toCheck, comp) >= 0;
+        }
+
+        internal static bool Contains(this string source, char toCheck, StringComparison comp)
+        {
+            return source?.IndexOf(toCheck) >= 0;
+        }
+#endif
+    }
+}


### PR DESCRIPTION
Add handling backticks in names in Connection helper methods to escape special characters in table/column names.

Fix GetTableInfo to read table comments properly.